### PR TITLE
Add generate_identity to ease testing

### DIFF
--- a/pmd_django/auth.py
+++ b/pmd_django/auth.py
@@ -1,3 +1,5 @@
+import json
+
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 import base64
@@ -43,3 +45,14 @@ def api_key_middleware(get_response):
         return res
 
     return _
+
+def generate_identity(payload: dict):
+    """Generates a signed identity for the given payload: {"email": "dev@techserv.com", "permissions": [{"resource": "all", "role": "dev"}]}"""
+    payload = json.dumps(payload)
+    private_jwk = jwk.JWK.generate(kty="OKP", crv="Ed25519")
+    public_jwk_b64 = base64.b64encode(private_jwk.export_public().encode("utf-8")).decode("utf-8")
+
+    signed = jws.JWS(payload.encode("utf-8"))
+    signed.add_signature(private_jwk, None, protected=json.dumps({"alg": "EdDSA"}))
+
+    return public_jwk_b64, signed.serialize(compact=True)

--- a/testapp/test_auth_middleware.py
+++ b/testapp/test_auth_middleware.py
@@ -2,18 +2,11 @@ import base64
 import json
 from django.test import TestCase, RequestFactory, override_settings
 from django.http import JsonResponse
-from jwcrypto import jwk, jws
-from pmd_django.auth import api_key_middleware
+from pmd_django.auth import api_key_middleware, generate_identity
 
 identity = {"email": "dev@techserv.com", "permissions": [{"resource": "all", "role": "dev"}]}
+(public_jwk_b64, signed_token) = generate_identity(identity)
 payload = json.dumps(identity)
-
-key = jwk.JWK.generate(kty="OKP", crv="Ed25519")
-public_jwk_b64 = base64.b64encode(key.export_public().encode("utf-8")).decode("utf-8")
-
-signed = jws.JWS(payload.encode("utf-8"))
-signed.add_signature(key, None, protected=json.dumps({"alg": "EdDSA"}))
-signed_token = signed.serialize(compact=True)
 
 @override_settings(AUTH_PUBLIC_KEY=public_jwk_b64)
 class TestAuthMiddleware(TestCase):


### PR DESCRIPTION
This is to enable easy testing while including auth, for example in `aep`

```python
from django.test import TestCase
from django.conf import settings
from pmd_django.auth import generate_identity


class BaseAuthTestCase(TestCase):
    def setUp(self):
        identity = {
            "email": "dev@techserv.com",
            "permissions": [{"resource": "all", "role": "dev"}],
        }

        self.public_jwk_b64, self.signed_identity_token = generate_identity(identity)
        settings.AUTH_PUBLIC_KEY = self.public_jwk_b64
        self.auth_headers = {"cookie": f"signedIdentity={self.signed_identity_token}"}

```

then 

```python
class StrategyTests(BaseAuthTestCase):
    def setUp(self):
        super().setUp()
		...

        def test_create_permit_with_related_data(self):
        payload = ...

        response = self.client.post(
            self.url,
            data=json.dumps(payload),
            content_type="application/json",
            headers=self.auth_headers,  // easy!
        )

        self.assertEqual(response.status_code, 200)
```
